### PR TITLE
Add receipt upload to expense detail page

### DIFF
--- a/expense-splitter/src/components/expense/ExpenseDetail.jsx
+++ b/expense-splitter/src/components/expense/ExpenseDetail.jsx
@@ -8,6 +8,8 @@ import ButtonFooter from "../ui/ButtonFooter";
 import Button from "../ui/Button";
 import db from "../../utils/localstoragedb";
 import Dialog from "../ui/Dialog";
+import ReceiptUpload from "../upload/ReceiptUpload";
+import DisplayReceipt from "../upload/DisplayReceipt";
 
 function ExpenseDetail() {
   const { expenses, groupData, friends, handleSetModal, setExpenses, modal } =
@@ -23,7 +25,6 @@ function ExpenseDetail() {
 
   // get expense details
   const expenseDetails = expenses.find((expense) => expense.id === expenseId);
-  console.log("expenseDetails", expenseDetails);
 
   // Closes or opens the dialog
   const toggleDialog = (ref) => {
@@ -91,9 +92,10 @@ function ExpenseDetail() {
 
   return (
     !modal.show && (
-      <div ref={downloadRef}>
+      <div ref={downloadRef} className="mb-16">
         <div className="mb-4 flex items-center">
           <i
+            data-html2canvas-ignore
             onClick={() => navigate("/expenses")}
             className="fa-solid fa-chevron-left cursor-pointer text-3xl text-accent"
           ></i>
@@ -111,7 +113,11 @@ function ExpenseDetail() {
           </p>
         </div>
         <PieChart label="Amount Owed" pieData={pieChartData} />
-        <div className="flex justify-end">
+        <div className="flex justify-between">
+          <DownloadPDF
+            filename={expenseDetails.name}
+            contentRef={downloadRef}
+          />
           <button
             className="text-xl underline"
             onClick={() => {
@@ -125,21 +131,16 @@ function ExpenseDetail() {
         <div>
           <>{memberDisplay}</>
         </div>
-        <div className="text-center">
-          {expenseDetails.receipt_URL !== null ? (
-            <a
-              href={expenseDetails.receipt_URL}
-              className="text-blue-400 underline"
-            >
-              Receipt
-            </a>
-          ) : null}
-        </div>
-        <DownloadPDF
-          filename={expenseDetails.name}
-          contentRef={downloadRef}
-          data-html2canvas-ignore
-        />
+        {expenseDetails.receipt_URL ? (
+          <DisplayReceipt expense={expenseDetails} setExpenses={setExpenses} />
+        ) : (
+          <ReceiptUpload
+            expenseDetails={expenseDetails}
+            setExpenses={setExpenses}
+            expenses={expenses}
+          />
+        )}
+
         <ButtonFooter>
           <Button
             className="bg-red-700"

--- a/expense-splitter/src/components/ui/Button.jsx
+++ b/expense-splitter/src/components/ui/Button.jsx
@@ -6,7 +6,7 @@ export default function Button({
   type,
   disabled,
 }) {
-  const baseStyles = "bg-accent whitespace-nowrap text-white ";
+  const baseStyles = "bg-accent whitespace-nowrap text-white cursor-pointer";
   const buttonStyles =
     variant === "small"
       ? "py-2 px-3 rounded-md hover:bg-secondary text-sm font-light"

--- a/expense-splitter/src/components/ui/Button.jsx
+++ b/expense-splitter/src/components/ui/Button.jsx
@@ -4,6 +4,7 @@ export default function Button({
   onClick,
   className,
   type,
+  disabled,
 }) {
   const baseStyles = "bg-accent whitespace-nowrap text-white ";
   const buttonStyles =
@@ -16,6 +17,7 @@ export default function Button({
       className={`${baseStyles} ${buttonStyles} ${className} transition-colors`}
       onClick={onClick}
       type={type}
+      disabled={disabled}
     >
       {children}
     </button>

--- a/expense-splitter/src/components/upload/DisplayReceipt.jsx
+++ b/expense-splitter/src/components/upload/DisplayReceipt.jsx
@@ -1,0 +1,57 @@
+import db from "../../utils/localstoragedb";
+import Dialog from "../ui/Dialog";
+import { useRef } from "react";
+import { ref, deleteObject } from "firebase/storage";
+import { storage } from "../../utils/firebase";
+
+const DisplayReceipt = ({ expense, setExpenses }) => {
+  const deleteReceiptRef = useRef(null);
+
+  const receiptRef = ref(storage, expense.receipt_URL);
+  const handleDeleteReceipt = () => {
+    // Delete file from firebase
+    deleteObject(receiptRef)
+      .then(() => {
+        // Remove url form local storage
+        db.update("expenses", { id: expense.id }, (expense) => {
+          expense.receipt_URL = null;
+          return expense;
+        });
+        db.commit();
+
+        // Update state
+        setExpenses(db.queryAll("expenses"));
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  };
+
+  return (
+    <>
+      <div className="relative">
+        <img src={expense.receipt_URL} alt={`Receipt for ${expense.name}`} />
+        <button
+          className="absolute right-1 top-1 rounded-full bg-slate-500 shadow-2xl shadow-cyan-700"
+          onClick={() => {
+            deleteReceiptRef.current.showModal();
+          }}
+        >
+          <i className="fa-solid fa-circle-xmark fa-3x opacity-60 shadow-2xl shadow-red-950 transition-all hover:scale-110 hover:opacity-95"></i>
+        </button>
+      </div>
+
+      <Dialog
+        dialogRef={deleteReceiptRef}
+        confirmOnClick={() => {
+          console.log("DELETED!");
+          handleDeleteReceipt();
+        }}
+      >
+        <p>Are you sure you want to delete this receipt?</p>
+      </Dialog>
+    </>
+  );
+};
+
+export default DisplayReceipt;

--- a/expense-splitter/src/components/upload/DisplayReceipt.jsx
+++ b/expense-splitter/src/components/upload/DisplayReceipt.jsx
@@ -29,7 +29,7 @@ const DisplayReceipt = ({ expense, setExpenses }) => {
 
   return (
     <>
-      <div className="relative">
+      <div className="relative" data-html2canvas-ignore>
         <img src={expense.receipt_URL} alt={`Receipt for ${expense.name}`} />
         <button
           className="absolute right-1 top-1 rounded-full bg-slate-500 shadow-2xl shadow-cyan-700"

--- a/expense-splitter/src/components/upload/DisplayReceipt.jsx
+++ b/expense-splitter/src/components/upload/DisplayReceipt.jsx
@@ -32,12 +32,12 @@ const DisplayReceipt = ({ expense, setExpenses }) => {
       <div className="relative" data-html2canvas-ignore>
         <img src={expense.receipt_URL} alt={`Receipt for ${expense.name}`} />
         <button
-          className="absolute right-1 top-1 rounded-full bg-slate-500 shadow-2xl shadow-cyan-700"
+          className="absolute right-1 top-1"
           onClick={() => {
             deleteReceiptRef.current.showModal();
           }}
         >
-          <i className="fa-solid fa-circle-xmark fa-3x opacity-60 shadow-2xl shadow-red-950 transition-all hover:scale-110 hover:opacity-95"></i>
+          <i className="fa-solid fa-circle-xmark fa-3x text-secondary opacity-70 transition-all hover:scale-110 hover:opacity-95 hover:drop-shadow-2xl"></i>
         </button>
       </div>
 

--- a/expense-splitter/src/components/upload/ReceiptUpload.jsx
+++ b/expense-splitter/src/components/upload/ReceiptUpload.jsx
@@ -60,28 +60,34 @@ const ReceiptUpload = () => {
   return (
     <>
       <form className="flex flex-col py-1" onSubmit={handleSubmit(onUpload)}>
-        <h2>Upload Receipt</h2>
-        <div className="flex items-center gap-4">
+        <p className="text-lg font-bold">
+          Upload Receipt
+          <span className="ml-2 text-sm font-light">
+            (File size must be less than 6MB)
+          </span>
+        </p>
+        <div className="flex items-center gap-4 py-2">
           <label
             htmlFor="upload"
-            className="flex h-12 w-36 cursor-pointer items-center justify-center rounded-lg bg-accent"
+            className="flex h-12 w-36 cursor-pointer items-center justify-center rounded-xl bg-accent transition-colors hover:bg-secondary hover:text-white"
           >
-            Select File
+            <i className="fa-solid fa-paperclip mr-2"></i>Select File
           </label>
-          <p className="text-sm font-light">
-            (File size must be less than 6MB)
-          </p>
+          <input
+            className="absolute h-[0.1px] w-[0.1px] p-2 opacity-0"
+            type="file"
+            id="upload"
+            {...register("upload")}
+          />
+          {/* Conditionally render button based on isSubmitting */}
+          <Button
+            type={"submit"}
+            disabled={isSubmitting || !isValid}
+            className={`bg-primary ${isValid ? "" : "cursor-default bg-slate-400 hover:bg-slate-400"}`}
+          >
+            {isSubmitting ? "Uploading..." : "Upload"}
+          </Button>
         </div>
-        <input
-          className="absolute h-[0.1px] w-[0.1px] p-2 opacity-0"
-          type="file"
-          id="upload"
-          {...register("upload")}
-        />
-        {/* Conditionally render button based on isSubmitting */}
-        <Button type={"submit"} disabled={isSubmitting || !isValid}>
-          {isSubmitting ? "Uploading..." : "Upload"}
-        </Button>
         {/* Render errors */}
         {errors.upload?.message && (
           <span className="text-red-500">{errors.upload.message}</span>

--- a/expense-splitter/src/components/upload/ReceiptUpload.jsx
+++ b/expense-splitter/src/components/upload/ReceiptUpload.jsx
@@ -62,7 +62,11 @@ const ReceiptUpload = ({ expenseDetails, setExpenses }) => {
 
   return (
     <>
-      <form className="flex flex-col py-1" onSubmit={handleSubmit(onUpload)}>
+      <form
+        data-html2canvas-ignore
+        className="flex flex-col py-1"
+        onSubmit={handleSubmit(onUpload)}
+      >
         <p className="text-lg font-bold">
           Upload Receipt
           <span className="ml-2 text-sm font-light">

--- a/expense-splitter/src/components/upload/ReceiptUpload.jsx
+++ b/expense-splitter/src/components/upload/ReceiptUpload.jsx
@@ -58,16 +58,20 @@ const ReceiptUpload = () => {
 
   return (
     <>
-      <form className="flex flex-col" onSubmit={handleSubmit(onUpload)}>
-        <h1>Upload Receipt</h1>
+      <form className="flex flex-col py-1" onSubmit={handleSubmit(onUpload)}>
         <div className="flex items-center gap-4">
-          <label htmlFor="upload">Upload File</label>
+          <label
+            htmlFor="upload"
+            className="flex h-12 w-36 cursor-pointer items-center justify-center rounded-lg bg-accent"
+          >
+            Select File
+          </label>
           <p className="text-sm font-light">
             (File size must be less than 6MB)
           </p>
         </div>
         <input
-          className="p-2"
+          className="absolute h-[0.1px] w-[0.1px] p-2 opacity-0"
           type="file"
           id="upload"
           {...register("upload")}

--- a/expense-splitter/src/components/upload/ReceiptUpload.jsx
+++ b/expense-splitter/src/components/upload/ReceiptUpload.jsx
@@ -7,7 +7,13 @@ import { useState } from "react";
 import { nanoid } from "nanoid";
 
 const MAX_FILE_SIZE = 6000000; //6MB
-const ACCEPTED_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
+const ACCEPTED_TYPES = [
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+  "application/pdf",
+];
 
 // Define validation schema
 const schema = z

--- a/expense-splitter/src/components/upload/ReceiptUpload.jsx
+++ b/expense-splitter/src/components/upload/ReceiptUpload.jsx
@@ -5,6 +5,7 @@ import { storage } from "../../utils/firebase";
 import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { useState } from "react";
 import { nanoid } from "nanoid";
+import Button from "../ui/Button";
 
 const MAX_FILE_SIZE = 6000000; //6MB
 const ACCEPTED_TYPES = [
@@ -59,6 +60,7 @@ const ReceiptUpload = () => {
   return (
     <>
       <form className="flex flex-col py-1" onSubmit={handleSubmit(onUpload)}>
+        <h2>Upload Receipt</h2>
         <div className="flex items-center gap-4">
           <label
             htmlFor="upload"
@@ -77,9 +79,9 @@ const ReceiptUpload = () => {
           {...register("upload")}
         />
         {/* Conditionally render button based on isSubmitting */}
-        <button type="submit" disabled={isSubmitting || !isValid}>
+        <Button type={"submit"} disabled={isSubmitting || !isValid}>
           {isSubmitting ? "Uploading..." : "Upload"}
-        </button>
+        </Button>
         {/* Render errors */}
         {errors.upload?.message && (
           <span className="text-red-500">{errors.upload.message}</span>

--- a/expense-splitter/src/components/upload/ReceiptUpload.jsx
+++ b/expense-splitter/src/components/upload/ReceiptUpload.jsx
@@ -76,12 +76,12 @@ const ReceiptUpload = ({ expenseDetails, setExpenses }) => {
     }
 
     if (bytes < 1024) {
-      return bytes + "bytes";
+      return `(${bytes} bytes)`;
     } else if (bytes < 1048576) {
       // 1024 * 1024
-      return (bytes / 1024).toFixed(2) + "KB";
+      return `(${(bytes / 1024).toFixed(2)}KB)`;
     } else {
-      return (bytes / 1048576).toFixed(2) + "MB";
+      return `(${(bytes / 1048576).toFixed(2)}MB)`;
     }
   };
 
@@ -120,7 +120,7 @@ const ReceiptUpload = ({ expenseDetails, setExpenses }) => {
             {isSubmitting ? "Uploading..." : "Upload"}
           </Button>
           <p className="font-medium">
-            {fileDetails.name} ({formatBytes(fileDetails.size)})
+            {fileDetails.name} {formatBytes(fileDetails.size)}
           </p>
         </div>
         {/* Render errors */}

--- a/expense-splitter/src/components/upload/ReceiptUpload.jsx
+++ b/expense-splitter/src/components/upload/ReceiptUpload.jsx
@@ -86,7 +86,7 @@ const ReceiptUpload = ({ expenseDetails, setExpenses }) => {
           <Button
             type={"submit"}
             disabled={isSubmitting || !isValid}
-            className={`bg-primary ${isValid ? "" : "cursor-default bg-slate-400 hover:bg-slate-400"}`}
+            className={`bg-primary ${isValid ? "" : "cursor-auto bg-slate-400 hover:bg-slate-400"}`}
           >
             {isSubmitting ? "Uploading..." : "Upload"}
           </Button>

--- a/expense-splitter/src/components/widgets/DownloadPDF.jsx
+++ b/expense-splitter/src/components/widgets/DownloadPDF.jsx
@@ -15,7 +15,7 @@ const DownloadPDF = ({ filename, contentRef }) => {
   };
 
   return (
-    <div data-html2canvas-ignore className="mb-16">
+    <div data-html2canvas-ignore>
       <Button onClick={convertToPDF} variant={"small"} className={"my-2"}>
         Download PDF
       </Button>


### PR DESCRIPTION
Users can upload a receipt on the expense detail page. It is uploaded to firebase and the url is stored within the expense object.

If the url exists within the expense object, it renders the receipt instead of the form with a button to delete the image from storage