### PR TITLE
Friend names are searched using expense weight data

### DIFF
--- a/expense-splitter/src/components/expense/ExpenseDetail.jsx
+++ b/expense-splitter/src/components/expense/ExpenseDetail.jsx
@@ -88,7 +88,6 @@ function ExpenseDetail() {
   });
 
   const memberDisplay = sortedContributions.map((friend) => {
-    console.log(friend);
     return (
       <Card
         key={friend.friendId}
@@ -100,8 +99,6 @@ function ExpenseDetail() {
       />
     );
   });
-
-  console.log(memberDisplay);
 
   return (
     !modal.show && (

--- a/expense-splitter/src/components/expense/ExpenseDetail.jsx
+++ b/expense-splitter/src/components/expense/ExpenseDetail.jsx
@@ -66,11 +66,6 @@ function ExpenseDetail() {
     (group) => group.id === expenseDetails.groupId,
   )[0];
 
-  // get friends names from goup
-  const friendNames = friends.filter((friend) =>
-    expenseGroup.friendIDs.includes(friend.id),
-  );
-
   // set data for pie chart to be array of contribution values
   const pieChartData = {};
 
@@ -93,17 +88,20 @@ function ExpenseDetail() {
   });
 
   const memberDisplay = sortedContributions.map((friend) => {
+    console.log(friend);
     return (
       <Card
         key={friend.friendId}
         icon={"fa-user"}
         hasButtons={true}
-        title={friendNames.find((i) => i.id === friend.friendId).name}
+        title={friends.find((i) => i.id === friend.friendId).name}
         subtitle={parseFloat(friend.percentage).toFixed(2) + "%"}
         price={((friend.percentage / 100) * expenseDetails.amount).toFixed(2)}
       />
     );
   });
+
+  console.log(memberDisplay);
 
   return (
     !modal.show && (


### PR DESCRIPTION
The expense detail page no longer throws an error when the group members are edited.

User can remove a friend from a group with existing expenses. The removed friend will be shown on previously created expense detail pages with no errors and will not be included in future expenses.